### PR TITLE
chore: add in vars to be passed through

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -13,11 +13,22 @@ on:
           - testflight
 
 jobs:
+  call_get_vars:
+    uses: ./.github/workflows/get-vars.yml  
+
   ios_build:
+    needs: call_get_vars
     # Calls the reusable workflow from the builder repo
     uses: IDEMSInternational/open-app-builder/.github/workflows/reusable-ios-release.yml@feat/ios-release-action
     with:
       target: ${{ github.event.inputs.target }} # "appetize" or "testflight"
+      APP_CODE_BRANCH: ${{ vars.APP_CODE_BRANCH }}
+      LFS_USED: ${{ needs.call_get_vars.outputs.LFS_USED == 'true' }}
+      DEPLOYMENT_NAME: ${{ needs.call_get_vars.outputs.DEPLOYMENT_NAME }}
+      PARENT_DEPLOYMENT_NAME: ${{ needs.call_get_vars.outputs.PARENT_DEPLOYMENT_NAME }}
+      PARENT_DEPLOYMENT_REPO: ${{ needs.call_get_vars.outputs.PARENT_DEPLOYMENT_REPO }}
+      PARENT_DEPLOYMENT_BRANCH: ${{ needs.call_get_vars.outputs.PARENT_DEPLOYMENT_BRANCH }}
+      ENCRYPTED: ${{ needs.call_get_vars.outputs.ENCRYPTED == 'true' }}
     secrets:
       DEPLOYMENT_PRIVATE_KEY: ${{ secrets.DEPLOYMENT_PRIVATE_KEY }}
       GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}


### PR DESCRIPTION
Fixes `ios-release` action by passing vars through in pattern used by https://github.com/IDEMSInternational/open-app-builder-actions/tree/main/content_repository_actions