### PR TITLE
chore: update ios-release action to target main branch of actions repo

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -19,7 +19,7 @@ jobs:
   ios_build:
     needs: call_get_vars
     # Calls the reusable workflow from the actions repo
-    uses: IDEMSInternational/open-app-builder-actions/.github/workflows/ios-release.yml@feat/ios-release-action
+    uses: IDEMSInternational/open-app-builder-actions/.github/workflows/ios-release.yml@main
     with:
       target: ${{ github.event.inputs.target }} # "appetize" or "testflight"
       CONTENT_BRANCH: ""


### PR DESCRIPTION
To be merged after https://github.com/IDEMSInternational/open-app-builder-actions/pull/28

Additionally, after merge, the `APP_CODE_BRANCH` repo variable that overwrites the org variable should be removed.